### PR TITLE
Fix smeltery quests, set faucet count to 2

### DIFF
--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -221,22 +221,23 @@
 				{
 					id: "784B9341FF645BFA",
 					type: "item",
-					item: "tconstruct:melter"
+					item: "tconstruct:seared_melter"
 				},
 				{
 					id: "665ACB0D249A1BE0",
 					type: "item",
-					item: "tconstruct:casting_table"
+					item: "tconstruct:seared_table"
 				},
 				{
 					id: "6B832F7F32649837",
 					type: "item",
-					item: "tconstruct:casting_basin"
+					item: "tconstruct:seared_basin"
 				},
 				{
 					id: "190DCB58C619E07B",
 					type: "item",
-					item: "tconstruct:faucet"
+					item: "tconstruct:seared_faucet",
+					count: 2L
 				},
 				{
 					id: "387E83E87AAF3C67",
@@ -246,7 +247,7 @@
 				{
 					id: "7BA2122D25F4DED9",
 					type: "item",
-					item: "tconstruct:seared_tank"
+					item: "tconstruct:seared_fuel_tank"
 				}
 			]
 		},


### PR DESCRIPTION
Faucet count is because you need two for the setup listed.